### PR TITLE
Fixes support for small batches with huge upserts

### DIFF
--- a/hippo_test.go
+++ b/hippo_test.go
@@ -643,7 +643,8 @@ func TestFlexStringCriteriaEncoding(t *testing.T) {
 	require.Equal(string(expect), string(actual))
 }
 
-// test splitting a batch that results in more parts than we have upserts
+// test splitting a batch with big enough upserts and small enough of a batch that initially, we to create
+// more batch parts than we have upserts. We then create one batch part per upsert.
 func TestSplitHugeUpserts(t *testing.T) {
 	r := require.New(t)
 

--- a/hippo_test.go
+++ b/hippo_test.go
@@ -648,7 +648,7 @@ func TestFlexStringCriteriaEncoding(t *testing.T) {
 func TestSplitHugeUpserts(t *testing.T) {
 	r := require.New(t)
 
-	// batch with 5 criteria, each with 15,000 IPs
+	// batch with 5 upserts, each with 15,000 IPs
 	addressesPerUpsert := 15000
 
 	ips := buildIPAddresses(addressesPerUpsert)

--- a/hippo_test.go
+++ b/hippo_test.go
@@ -722,11 +722,7 @@ func TestSplitHugeUpserts(t *testing.T) {
 		r.Equal(1, len(parts[i].Upserts))
 		r.Equal(1, len(parts[i].Upserts[0].Criteria))
 		r.Equal(addressesPerUpsert, len(parts[i].Upserts[0].Criteria[0].IPAddresses))
-
-		// verify we're sorted by value
-		r.Equal(fmt.Sprintf("test%d", i+1), parts[i].Upserts[0].Value)
 	}
-
 }
 
 // build a list of IP addresses


### PR DESCRIPTION
Fixes #11

When there are huge upserts (say, with thousands of IP addresses),
in small batches, it was possible for the "upserts per batch"
calculation to return zero. This ends up submitting N-1 empty batches,
then trying to send all upserts through the last one, which might be too
much for the server. This fixes that situation by making sure we send at
least one upsert per batch, then only send as many batches as needed.