### PR TITLE
Added BatchBuilder to help split batches with more smarts

### DIFF
--- a/batch_builder.go
+++ b/batch_builder.go
@@ -1,0 +1,203 @@
+package hippo
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+)
+
+// BatchBuilder is responsible for building a batch that will serialize within a desired size if possible.
+// It'll fit big and small populators together, but doesn't try to do so optimally.
+type BatchBuilder struct {
+	desiredSize       int
+	buf               *bytes.Buffer
+	serializedUpserts [][]byte
+	batchGUID         string
+	replaceAll        bool
+	ttlMinutes        int
+	builtBatchesCount int
+	hasClosedBatch    bool
+}
+
+// NewBatchBuilder builds a new BatchBuilder
+func NewBatchBuilder(desiredSize int, replaceAll bool, ttlMinutes int) *BatchBuilder {
+	return &BatchBuilder{
+		desiredSize:       desiredSize,
+		serializedUpserts: make([][]byte, 0),
+		replaceAll:        replaceAll,
+		ttlMinutes:        ttlMinutes,
+		buf:               bytes.NewBuffer(make([]byte, 0, desiredSize)),
+	}
+}
+
+// Reset resets the batch builder to build a new batch, reusing the underlying buffer.
+func (b *BatchBuilder) Reset(desiredSize int, replaceAll bool, ttlMinutes int) {
+	b.desiredSize = desiredSize
+	b.serializedUpserts = b.serializedUpserts[:0]
+	b.batchGUID = ""
+	b.replaceAll = replaceAll
+	b.ttlMinutes = ttlMinutes
+	b.builtBatchesCount = 0
+	b.hasClosedBatch = false
+}
+
+// AddUpsert attempts to add the input upsert into the batch.
+// Make sure to add all upserts to the batch before calling BuildBatch()
+func (b *BatchBuilder) AddUpsert(upsert *TagUpsert) error {
+	ser, err := json.Marshal(upsert)
+	if err != nil {
+		return fmt.Errorf("Error serializing TagUpsert: %s", err)
+	}
+	b.serializedUpserts = append(b.serializedUpserts, ser)
+	return nil
+}
+
+// SetBatchGUID sets the GUID that was returned after submitting the first part to the server.
+func (b *BatchBuilder) SetBatchGUID(guid string) {
+	b.batchGUID = guid
+}
+
+// BuildBatch builds and returns a serialized batch.
+// Once this method is called, don't make any further calls to AddUpsert.
+func (b *BatchBuilder) BuildBatch() ([]byte, error) {
+	if len(b.serializedUpserts) == 0 && b.hasClosedBatch {
+		// nothing to do
+		return nil, nil
+	}
+
+	if b.batchGUID == "" && b.builtBatchesCount > 0 {
+		return nil, fmt.Errorf("Only first batch may be sent without batch GUID")
+	}
+
+	b.buf.Reset()
+
+	// sort upserts by serialized size
+	sort.SliceStable(b.serializedUpserts, func(i int, j int) bool {
+		return len(b.serializedUpserts[i]) < len(b.serializedUpserts[j])
+	})
+
+	// estimate how much data we have
+	dataSize := 0
+	for _, serializedUpsert := range b.serializedUpserts {
+		dataSize += len(serializedUpsert)
+	}
+
+	// guid
+	if _, err := b.buf.WriteString(`{"guid":"`); err != nil {
+		return nil, fmt.Errorf("Error writing string to buffer: %s", err)
+	}
+	if _, err := b.buf.WriteString(b.batchGUID); err != nil {
+		return nil, fmt.Errorf("Error writing string to buffer: %s", err)
+	}
+
+	// replace_all
+	if _, err := b.buf.WriteString(`","replace_all":`); err != nil {
+		return nil, fmt.Errorf("Error writing string to buffer: %s", err)
+	}
+	if _, err := b.buf.WriteString(boolString(b.replaceAll)); err != nil {
+		return nil, fmt.Errorf("Error writing string to buffer: %s", err)
+	}
+
+	// ttl_minutes
+	if _, err := b.buf.WriteString(`,"ttl_minutes":`); err != nil {
+		return nil, fmt.Errorf("Error writing string to buffer: %s", err)
+	}
+	if _, err := b.buf.WriteString(strconv.Itoa(b.ttlMinutes)); err != nil {
+		return nil, fmt.Errorf("Error writing string to buffer: %s", err)
+	}
+
+	// upserts start
+	if _, err := b.buf.WriteString(`,"upserts":[`); err != nil {
+		return nil, fmt.Errorf("Error writing string to buffer: %s", err)
+	}
+
+	// build a batch as big as we can
+	start := 0
+	end := len(b.serializedUpserts) - 1
+
+	// leave some space for batch scaffolding and `"complete":false`
+	availableSpace := b.desiredSize - b.buf.Len() - 40
+
+	upsertCount := 0
+	for {
+		if start > end || availableSpace <= 0 {
+			break
+		}
+
+		// try the bigger upserts first
+		if len(b.serializedUpserts[end]) <= availableSpace {
+			if upsertCount > 0 {
+				if _, err := b.buf.WriteString(","); err != nil {
+					return nil, fmt.Errorf("Error writing string to buffer: %s", err)
+				}
+				availableSpace--
+			}
+			if _, err := b.buf.Write(b.serializedUpserts[end]); err != nil {
+				return nil, fmt.Errorf("Error writing string to buffer: %s", err)
+			}
+			availableSpace -= len(b.serializedUpserts[end])
+
+			b.serializedUpserts[end] = nil
+
+			upsertCount++
+			end--
+			continue
+		}
+
+		// couldn't fit the bigger one - try smaller
+		if len(b.serializedUpserts[start]) <= availableSpace {
+			if upsertCount > 0 {
+				if _, err := b.buf.WriteString(","); err != nil {
+					return nil, fmt.Errorf("Error writing string to buffer: %s", err)
+				}
+				availableSpace--
+			}
+			if _, err := b.buf.Write(b.serializedUpserts[start]); err != nil {
+				return nil, fmt.Errorf("Error writing string to buffer: %s", err)
+			}
+			availableSpace -= len(b.serializedUpserts[start])
+
+			b.serializedUpserts[start] = nil
+
+			upsertCount++
+			start++
+			continue
+		}
+
+		break
+	}
+
+	if upsertCount == 0 {
+		return nil, fmt.Errorf("Have %d remaining upserts, but could not fit any into the batch. The smallest one is %d bytes", len(b.serializedUpserts), len(b.serializedUpserts[start]))
+	}
+	if _, err := b.buf.WriteString(`]`); err != nil {
+		return nil, fmt.Errorf("Error writing string to buffer: %s", err)
+	}
+
+	// is_complete
+	if _, err := b.buf.WriteString(`,"complete":`); err != nil {
+		return nil, fmt.Errorf("Error writing string to buffer: %s", err)
+	}
+	if _, err := b.buf.WriteString(boolString(start > end)); err != nil {
+		return nil, fmt.Errorf("Error writing string to buffer: %s", err)
+	}
+	b.hasClosedBatch = start > end
+
+	if _, err := b.buf.WriteString(`}`); err != nil {
+		return nil, fmt.Errorf("Error writing string to buffer: %s", err)
+	}
+
+	b.serializedUpserts = b.serializedUpserts[start : end+1]
+
+	b.builtBatchesCount++
+	return b.buf.Bytes(), nil
+}
+
+func boolString(val bool) string {
+	if val {
+		return "true"
+	}
+	return "false"
+}

--- a/batch_builder.go
+++ b/batch_builder.go
@@ -63,11 +63,6 @@ func (b *BatchBuilder) AddUpsert(upsert *TagUpsert) error {
 	if err != nil {
 		return fmt.Errorf("Error serializing TagUpsert: %s", err)
 	}
-
-	if len(ser) > b.desiredSize-300 {
-		return fmt.Errorf("Cannot add upsert with value: %s, serialized length: %d - too big for batch with max size of %d", upsert.Value, len(ser), b.desiredSize)
-	}
-
 	b.serializedUpserts = append(b.serializedUpserts, ser)
 	return nil
 }

--- a/batch_builder.go
+++ b/batch_builder.go
@@ -140,11 +140,7 @@ func (b *BatchBuilder) BuildBatch() ([]byte, int, error) {
 	availableSpace := b.desiredSize - b.buf.Len() - 40
 
 	upsertCount := 0
-	for {
-		if start > end || availableSpace <= 0 {
-			break
-		}
-
+	for start <= end && availableSpace > 0 {
 		// try the bigger upserts first
 		if len(b.serializedUpserts[end]) <= availableSpace {
 			if upsertCount > 0 {
@@ -185,8 +181,9 @@ func (b *BatchBuilder) BuildBatch() ([]byte, int, error) {
 			continue
 		}
 
+		// smaller wouldn't fit either
 		if upsertCount == 0 {
-			// couldn't fit anything in this batch
+			// batch is empty
 			return nil, 0, fmt.Errorf("Have %d remaining upserts, but could not fit any into the batch. The smallest one is %d bytes", len(b.serializedUpserts), len(b.serializedUpserts[start]))
 		}
 		break

--- a/batch_builder.go
+++ b/batch_builder.go
@@ -63,6 +63,11 @@ func (b *BatchBuilder) AddUpsert(upsert *TagUpsert) error {
 	if err != nil {
 		return fmt.Errorf("Error serializing TagUpsert: %s", err)
 	}
+
+	if len(ser) > b.desiredSize-300 {
+		return fmt.Errorf("Cannot add upsert with value: %s, serialized length: %d - too big for batch with max size of %d", upsert.Value, len(ser), b.desiredSize)
+	}
+
 	b.serializedUpserts = append(b.serializedUpserts, ser)
 	return nil
 }

--- a/batch_builder.go
+++ b/batch_builder.go
@@ -88,12 +88,6 @@ func (b *BatchBuilder) BuildBatch() ([]byte, int, error) {
 		return len(b.serializedUpserts[i]) < len(b.serializedUpserts[j])
 	})
 
-	// estimate how much data we have
-	dataSize := 0
-	for _, serializedUpsert := range b.serializedUpserts {
-		dataSize += len(serializedUpsert)
-	}
-
 	// guid
 	if _, err := b.buf.WriteString(`{"guid":"`); err != nil {
 		return nil, 0, fmt.Errorf("Error writing string to buffer: %s", err)

--- a/batch_builder_test.go
+++ b/batch_builder_test.go
@@ -33,7 +33,7 @@ func TestBatchBuilder_FailureOverLimit(t *testing.T) {
 			Value: fmt.Sprintf("big_%d_%s", i, stringOfLength(i+1)),
 			Criteria: []TagCriteria{
 				{
-					Direction:   "asc",
+					Direction:   "src",
 					IPAddresses: ips,
 				},
 			},
@@ -46,7 +46,7 @@ func TestBatchBuilder_FailureOverLimit(t *testing.T) {
 			Value: fmt.Sprintf("small_%d_%s", i, stringOfLength(i+1)),
 			Criteria: []TagCriteria{
 				{
-					Direction:   "asc",
+					Direction:   "src",
 					IPAddresses: []string{"5.1.5.1"},
 				},
 			},
@@ -198,7 +198,7 @@ func TestBatchBuilder_SuccessOneBatch(t *testing.T) {
 			Value: nameFor(i),
 			Criteria: []TagCriteria{
 				{
-					Direction:   "asc",
+					Direction:   "src",
 					IPAddresses: []string{fmt.Sprintf("1.2.3.%d", i)},
 				},
 			},
@@ -221,7 +221,7 @@ func TestBatchBuilder_SuccessOneBatch(t *testing.T) {
 				Value: "value_A_A_A_A_A_5",
 				Criteria: []TagCriteria{
 					{
-						Direction:   "asc",
+						Direction:   "src",
 						IPAddresses: []string{"1.2.3.5"},
 					},
 				},
@@ -230,7 +230,7 @@ func TestBatchBuilder_SuccessOneBatch(t *testing.T) {
 				Value: "value_A_A_A_A_4",
 				Criteria: []TagCriteria{
 					{
-						Direction:   "asc",
+						Direction:   "src",
 						IPAddresses: []string{"1.2.3.4"},
 					},
 				},
@@ -239,7 +239,7 @@ func TestBatchBuilder_SuccessOneBatch(t *testing.T) {
 				Value: "value_A_A_A_3",
 				Criteria: []TagCriteria{
 					{
-						Direction:   "asc",
+						Direction:   "src",
 						IPAddresses: []string{"1.2.3.3"},
 					},
 				},
@@ -248,7 +248,7 @@ func TestBatchBuilder_SuccessOneBatch(t *testing.T) {
 				Value: "value_A_A_2",
 				Criteria: []TagCriteria{
 					{
-						Direction:   "asc",
+						Direction:   "src",
 						IPAddresses: []string{"1.2.3.2"},
 					},
 				},
@@ -257,7 +257,7 @@ func TestBatchBuilder_SuccessOneBatch(t *testing.T) {
 				Value: "value_A_1",
 				Criteria: []TagCriteria{
 					{
-						Direction:   "asc",
+						Direction:   "src",
 						IPAddresses: []string{"1.2.3.1"},
 					},
 				},
@@ -303,7 +303,7 @@ func TestBatchBuilder_SuccessTwoBatches(t *testing.T) {
 			Value: nameFor(i),
 			Criteria: []TagCriteria{
 				{
-					Direction:   "asc",
+					Direction:   "src",
 					IPAddresses: []string{fmt.Sprintf("1.2.3.%d", i)},
 				},
 			},
@@ -326,7 +326,7 @@ func TestBatchBuilder_SuccessTwoBatches(t *testing.T) {
 				Value: "value_A_A_A_A_A_5",
 				Criteria: []TagCriteria{
 					{
-						Direction:   "asc",
+						Direction:   "src",
 						IPAddresses: []string{"1.2.3.5"},
 					},
 				},
@@ -335,7 +335,7 @@ func TestBatchBuilder_SuccessTwoBatches(t *testing.T) {
 				Value: "value_A_A_A_A_4",
 				Criteria: []TagCriteria{
 					{
-						Direction:   "asc",
+						Direction:   "src",
 						IPAddresses: []string{"1.2.3.4"},
 					},
 				},
@@ -344,7 +344,7 @@ func TestBatchBuilder_SuccessTwoBatches(t *testing.T) {
 				Value: "value_A_A_A_3",
 				Criteria: []TagCriteria{
 					{
-						Direction:   "asc",
+						Direction:   "src",
 						IPAddresses: []string{"1.2.3.3"},
 					},
 				},
@@ -375,7 +375,7 @@ func TestBatchBuilder_SuccessTwoBatches(t *testing.T) {
 				Value: "value_A_A_2",
 				Criteria: []TagCriteria{
 					{
-						Direction:   "asc",
+						Direction:   "src",
 						IPAddresses: []string{"1.2.3.2"},
 					},
 				},
@@ -384,7 +384,7 @@ func TestBatchBuilder_SuccessTwoBatches(t *testing.T) {
 				Value: "value_A_1",
 				Criteria: []TagCriteria{
 					{
-						Direction:   "asc",
+						Direction:   "src",
 						IPAddresses: []string{"1.2.3.1"},
 					},
 				},
@@ -420,7 +420,7 @@ func TestBatchBuilder_SuccessWithBigAndSmallUpserts(t *testing.T) {
 				Value: fmt.Sprintf("big_%d", i),
 				Criteria: []TagCriteria{
 					{
-						Direction:   "asc",
+						Direction:   "src",
 						IPAddresses: ips,
 					},
 				},
@@ -441,7 +441,7 @@ func TestBatchBuilder_SuccessWithBigAndSmallUpserts(t *testing.T) {
 				Value: fmt.Sprintf("small_%d", i),
 				Criteria: []TagCriteria{
 					{
-						Direction:   "asc",
+						Direction:   "src",
 						IPAddresses: ips,
 					},
 				},

--- a/batch_builder_test.go
+++ b/batch_builder_test.go
@@ -1,0 +1,153 @@
+package hippo
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// test batch building when every populator is too big for a single batch
+func TestBatchBuilder_FailureImpossible(t *testing.T) {
+	a := require.New(t)
+
+	maxSize := 10000
+	sut := NewBatchBuilder(maxSize, true, 0)
+
+	// 10 populators, 1000 IP addresses each - each populator is 11,630 bytes
+	ips := buildIPAddresses(1000)
+	for i := 0; i < 10; i++ {
+		a.NoError(sut.AddUpsert(&TagUpsert{
+			Value: fmt.Sprintf("abcdef_%d", i),
+			Criteria: []TagCriteria{
+				{
+					Direction:   "asc",
+					IPAddresses: ips,
+				},
+			},
+		}))
+	}
+
+	batchBytes, err := sut.BuildBatch()
+	a.Nil(batchBytes)
+	a.Error(err)
+	a.Equal("Have 10 remaining upserts, but could not fit any into the batch. The smallest one is 11630 bytes", err.Error())
+}
+
+// test building a batch from big and small upserts
+// - also tests that batch guid is necessary on batch parts 2-N
+func TestBatchBuilder_SuccessWithBigAndSmallUpserts(t *testing.T) {
+	a := require.New(t)
+
+	// picked a good size that spreads out big and little populators
+	maxSize := 12220
+	sut := NewBatchBuilder(maxSize, true, 13)
+
+	runTest := func() {
+		// 5 big populators 11,630 bytes each
+		ips := buildIPAddresses(1000)
+		for i := 0; i < 5; i++ {
+			upsert := TagUpsert{
+				Value: fmt.Sprintf("big_%d", i),
+				Criteria: []TagCriteria{
+					{
+						Direction:   "asc",
+						IPAddresses: ips,
+					},
+				},
+			}
+			if i == 0 {
+				// make sure the serialized upsert is the size we think
+				batchBytes, err := json.Marshal(upsert)
+				a.NoError(err)
+				a.Equal(11627, len(batchBytes))
+			}
+			a.NoError(sut.AddUpsert(&upsert))
+		}
+
+		// 5 populators with 10 IP addresses each - 163 bytes per upsert
+		ips = buildIPAddresses(10)
+		for i := 0; i < 5; i++ {
+			upsert := TagUpsert{
+				Value: fmt.Sprintf("small_%d", i),
+				Criteria: []TagCriteria{
+					{
+						Direction:   "asc",
+						IPAddresses: ips,
+					},
+				},
+			}
+			a.NoError(sut.AddUpsert(&upsert))
+
+			if i == 0 {
+				// make sure the serialized upsert is the size we think
+				batchBytes, err := json.Marshal(upsert)
+				a.NoError(err)
+				a.Equal(162, len(batchBytes))
+			}
+		}
+
+		verifyBatch := func(bigCount int, smallCount int, guid string, batchSizeBytes int, isComplete bool, ttlMinutes uint32) {
+			batchBytes, err := sut.BuildBatch()
+			a.NoError(err)
+			a.NotNil(batchBytes)
+			a.Equal(batchSizeBytes, len(batchBytes))
+			a.True(len(batchBytes) <= maxSize)
+
+			// make sure the batch is proper JSON
+			batch := TagBatchPart{}
+			a.NoError(json.Unmarshal(batchBytes, &batch))
+
+			a.Equal(guid, batch.BatchGUID)
+			a.Equal(isComplete, batch.IsComplete)
+			a.Equal(ttlMinutes, batch.TTLMinutes)
+
+			// make sure we have the right number of big and small upserts
+			foundBigCount := 0
+			foundSmallCount := 0
+			for _, upsert := range batch.Upserts {
+				a.Equal(1, len(upsert.Criteria))
+				if strings.HasPrefix(upsert.Value, "small_") {
+					foundSmallCount++
+					a.Equal(10, len(upsert.Criteria[0].IPAddresses))
+				} else if strings.HasPrefix(upsert.Value, "big_") {
+					foundBigCount++
+					a.Equal(1000, len(upsert.Criteria[0].IPAddresses))
+				} else {
+					a.FailNow("Invalid value: %s", upsert.Value)
+				}
+			}
+			a.Equal(bigCount, foundBigCount)
+			a.Equal(smallCount, foundSmallCount)
+		}
+
+		// 5 batches - each one has one big populator. First one has 3 small, second has 2 small
+		verifyBatch(1, 3, "", 12193, false, 13)
+
+		// now try to build a batch without providing GUID, and expect it'll fail
+		batchBytes, err := sut.BuildBatch()
+		a.Nil(batchBytes)
+		a.Error(err)
+		a.Equal("Only first batch may be sent without batch GUID", err.Error())
+
+		// set the GUID and try again
+		sut.SetBatchGUID("705e4dcb-3ecd-24f3-3a35-3e926e4bded5")
+
+		verifyBatch(1, 2, "705e4dcb-3ecd-24f3-3a35-3e926e4bded5", 12066, false, 13)
+		verifyBatch(1, 0, "705e4dcb-3ecd-24f3-3a35-3e926e4bded5", 11740, false, 13)
+		verifyBatch(1, 0, "705e4dcb-3ecd-24f3-3a35-3e926e4bded5", 11740, false, 13)
+		verifyBatch(1, 0, "705e4dcb-3ecd-24f3-3a35-3e926e4bded5", 11739, true, 13)
+
+		// make sure that the batch builder knows it's done
+		batchBytes, err = sut.BuildBatch()
+		a.Nil(batchBytes)
+		a.NoError(err)
+	}
+
+	// run the test twice to make sure we can reuse SUT
+	runTest()
+	sut.Reset(maxSize, true, 13)
+	runTest()
+}

--- a/batch_builder_test.go
+++ b/batch_builder_test.go
@@ -9,35 +9,32 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// test batch building when one populator is too big to fit
+// test batch building when every populator is too big for a single batch
 func TestBatchBuilder_FailureImpossible(t *testing.T) {
 	a := require.New(t)
 
 	maxSize := 10000
 	sut := NewBatchBuilder(maxSize, true, 0)
 
-	// 2 populators, one that's 11,632 bytes
-	a.NoError(sut.AddUpsert(&TagUpsert{
-		Value: "fits",
-		Criteria: []TagCriteria{
-			{
-				Direction:   "asc",
-				IPAddresses: buildIPAddresses(1),
+	// 10 populators, 1000 IP addresses each - each populator is 11,630 bytes
+	ips := buildIPAddresses(1000)
+	for i := 0; i < 10; i++ {
+		a.NoError(sut.AddUpsert(&TagUpsert{
+			Value: fmt.Sprintf("abcdef_%d", i),
+			Criteria: []TagCriteria{
+				{
+					Direction:   "asc",
+					IPAddresses: ips,
+				},
 			},
-		},
-	}))
+		}))
+	}
 
-	err := sut.AddUpsert(&TagUpsert{
-		Value: "doesnt_fit",
-		Criteria: []TagCriteria{
-			{
-				Direction:   "asc",
-				IPAddresses: buildIPAddresses(1000),
-			},
-		},
-	})
+	batchBytes, upsertCount, err := sut.BuildBatchRequest()
+	a.Nil(batchBytes)
 	a.Error(err)
-	a.Equal("Cannot add upsert with value: doesnt_fit, serialized length: 11632 - too big for batch with max size of 10000", err.Error())
+	a.Equal("Have 10 remaining upserts, but could not fit any into the batch. The smallest one is 11630 bytes", err.Error())
+	a.Zero(upsertCount)
 }
 
 // test building an empty replace-all bach does build an empty batch - once
@@ -293,11 +290,6 @@ func TestBatchBuilder_SuccessTwoBatches(t *testing.T) {
 	receivedBatch := TagBatchPart{}
 	a.NoError(json.Unmarshal(batchBytes, &receivedBatch))
 	a.True(expectedBatch.Equal(receivedBatch))
-
-	// verify we can't add more upserts
-	err = sut.AddUpsert(&TagUpsert{Value: "abcdefg12345", Criteria: []TagCriteria{{Direction: "asc", IPAddresses: []string{"1.2.3.4"}}}})
-	a.Error(err)
-	a.Equal("Cannot add upsert after a batch has been built", err.Error())
 
 	// batch 2: 2 upserts
 	sut.SetBatchGUID("805e4dcb-3ecd-24f3-3a35-3e926e4bded5")

--- a/hippo.go
+++ b/hippo.go
@@ -194,7 +194,7 @@ func (c *Client) SendBatch(ctx context.Context, url string, batch *TagBatchPart)
 		}
 		responseBytes, err := c.Do(ctx, req)
 		if err != nil {
-			return ret, fmt.Errorf("Error POSTing populators to %s - [%s] - underlying error: %s", url, ret, err)
+			return ret, fmt.Errorf("Error POSTing populators to %s (%d bytes) - [%s] - underlying error: %s", url, len(gzippedBytes), ret, err)
 		}
 
 		if ret.PartsSent == 0 {

--- a/hippo.go
+++ b/hippo.go
@@ -171,7 +171,7 @@ func (c *Client) SendBatch(ctx context.Context, url string, batch *TagBatchPart)
 	}
 	for {
 		batchBuilder.SetBatchGUID(ret.BatchGUID)
-		requestBytes, upsertCount, err := batchBuilder.BuildBatch()
+		requestBytes, upsertCount, err := batchBuilder.BuildBatchRequest()
 		if err != nil {
 			return ret, fmt.Errorf("Error building batch: %s", err)
 		}

--- a/hippo_test.go
+++ b/hippo_test.go
@@ -531,7 +531,7 @@ func TestMultiPartBatch_PartialSuccess(t *testing.T) {
 	url := fmt.Sprintf("%s/kentik/server/url", ts.URL)
 	response, err := sut.SendBatch(context.Background(), url, &batch)
 	a.Error(err)
-	expectedErrorStr := fmt.Sprintf(`Error POSTing populators to %s/kentik/server/url - [Batch GUID: c8285742-f7a4-4870-933d-665b15c31eda; Progress: 1 parts sent, 2/5 upserts, 0/0 deletes] - underlying error: http error 500: server error occurred`, ts.URL)
+	expectedErrorStr := fmt.Sprintf(`Error POSTing populators to %s/kentik/server/url (232 bytes) - [Batch GUID: c8285742-f7a4-4870-933d-665b15c31eda; Progress: 1 parts sent, 2/5 upserts, 0/0 deletes] - underlying error: http error 500: server error occurred`, ts.URL)
 	a.Equal(expectedErrorStr, err.Error())
 	a.NotNil(response)
 

--- a/hippo_test.go
+++ b/hippo_test.go
@@ -56,7 +56,7 @@ func TestSinglePartBatch_Success(t *testing.T) {
 		jsonPayload := getJSON(a, r)
 
 		// verify the expected request
-		expectedRequest := `{"guid":"","replace_all":true,"ttl_minutes":0,"sender":{"service_name":"my-service","service_instance":"service-instance-1","host_name":"my-host-name"},"upserts":[{"value":"test1","criteria":[{"direction":"asc","addr":["1.2.3.4"]}]}],"complete":true}`
+		expectedRequest := `{"guid":"","replace_all":true,"ttl_minutes":0,"sender":{"service_name":"my-service","service_instance":"service-instance-1","host_name":"my-host-name"},"upserts":[{"value":"test1","criteria":[{"direction":"src","addr":["1.2.3.4"]}]}],"complete":true}`
 		a.Equal(expectedRequest, string(jsonPayload))
 
 		// write the canned response
@@ -80,7 +80,7 @@ func TestSinglePartBatch_Success(t *testing.T) {
 				Value: "test1",
 				Criteria: []TagCriteria{
 					{
-						Direction:   "asc",
+						Direction:   "src",
 						IPAddresses: []string{"1.2.3.4"},
 					},
 				},
@@ -130,7 +130,7 @@ func TestSinglePartBatch_Error(t *testing.T) {
 		jsonPayload := getJSON(a, r)
 
 		// verify the expected request
-		expectedRequest := `{"guid":"","replace_all":true,"ttl_minutes":0,"sender":{"service_name":"my-service","service_instance":"service-instance-1","host_name":"my-host-name"},"upserts":[{"value":"test1","criteria":[{"direction":"asc","addr":["1.2.3.4"]}]}],"complete":true}`
+		expectedRequest := `{"guid":"","replace_all":true,"ttl_minutes":0,"sender":{"service_name":"my-service","service_instance":"service-instance-1","host_name":"my-host-name"},"upserts":[{"value":"test1","criteria":[{"direction":"src","addr":["1.2.3.4"]}]}],"complete":true}`
 		a.Equal(expectedRequest, string(jsonPayload))
 
 		// write the canned response
@@ -154,7 +154,7 @@ func TestSinglePartBatch_Error(t *testing.T) {
 				Value: "test1",
 				Criteria: []TagCriteria{
 					{
-						Direction:   "asc",
+						Direction:   "src",
 						IPAddresses: []string{"1.2.3.4"},
 					},
 				},
@@ -206,7 +206,7 @@ func TestSinglePartBatch_MissingGUID(t *testing.T) {
 		jsonPayload := getJSON(a, r)
 
 		// verify the expected request
-		expectedRequest := `{"guid":"","replace_all":true,"ttl_minutes":0,"sender":{"service_name":"my-service","service_instance":"service-instance-1","host_name":"my-host-name"},"upserts":[{"value":"test1","criteria":[{"direction":"asc","addr":["1.2.3.4"]}]}],"complete":true}`
+		expectedRequest := `{"guid":"","replace_all":true,"ttl_minutes":0,"sender":{"service_name":"my-service","service_instance":"service-instance-1","host_name":"my-host-name"},"upserts":[{"value":"test1","criteria":[{"direction":"src","addr":["1.2.3.4"]}]}],"complete":true}`
 		a.Equal(expectedRequest, string(jsonPayload))
 
 		// write the canned response
@@ -230,7 +230,7 @@ func TestSinglePartBatch_MissingGUID(t *testing.T) {
 				Value: "test1",
 				Criteria: []TagCriteria{
 					{
-						Direction:   "asc",
+						Direction:   "src",
 						IPAddresses: []string{"1.2.3.4"},
 					},
 				},
@@ -275,13 +275,13 @@ func TestMultiPartBatch_Success(t *testing.T) {
 	// expecting 3 requests
 	expectedRequests := []string{
 		// first request has no GUID, and has complete=false
-		`{"guid":"","replace_all":true,"ttl_minutes":0,"sender":{"service_name":"my-service","service_instance":"service-instance-1","host_name":"my-host-name"},"upserts":[{"value":"test5","criteria":[{"direction":"asc","addr":["5.2.3.4"]}]},{"value":"test4","criteria":[{"direction":"asc","addr":["4.2.3.4"]}]}],"complete":false}`,
+		`{"guid":"","replace_all":true,"ttl_minutes":0,"sender":{"service_name":"my-service","service_instance":"service-instance-1","host_name":"my-host-name"},"upserts":[{"value":"test5","criteria":[{"direction":"src","addr":["5.2.3.4"]}]},{"value":"test4","criteria":[{"direction":"src","addr":["4.2.3.4"]}]}],"complete":false}`,
 
 		// second request has the GUID, and has complete=false
-		`{"guid":"c8285742-f7a4-4870-933d-665b15c31eda","replace_all":true,"ttl_minutes":0,"sender":{"service_name":"my-service","service_instance":"service-instance-1","host_name":"my-host-name"},"upserts":[{"value":"test3","criteria":[{"direction":"asc","addr":["3.2.3.4"]}]},{"value":"test2","criteria":[{"direction":"asc","addr":["2.2.3.4"]}]}],"complete":false}`,
+		`{"guid":"c8285742-f7a4-4870-933d-665b15c31eda","replace_all":true,"ttl_minutes":0,"sender":{"service_name":"my-service","service_instance":"service-instance-1","host_name":"my-host-name"},"upserts":[{"value":"test3","criteria":[{"direction":"src","addr":["3.2.3.4"]}]},{"value":"test2","criteria":[{"direction":"src","addr":["2.2.3.4"]}]}],"complete":false}`,
 
 		// third request has the GUID, and complete=true
-		`{"guid":"c8285742-f7a4-4870-933d-665b15c31eda","replace_all":true,"ttl_minutes":0,"sender":{"service_name":"my-service","service_instance":"service-instance-1","host_name":"my-host-name"},"upserts":[{"value":"test1","criteria":[{"direction":"asc","addr":["1.2.3.4"]}]}],"complete":true}`,
+		`{"guid":"c8285742-f7a4-4870-933d-665b15c31eda","replace_all":true,"ttl_minutes":0,"sender":{"service_name":"my-service","service_instance":"service-instance-1","host_name":"my-host-name"},"upserts":[{"value":"test1","criteria":[{"direction":"src","addr":["1.2.3.4"]}]}],"complete":true}`,
 	}
 
 	lock := sync.Mutex{}
@@ -327,7 +327,7 @@ func TestMultiPartBatch_Success(t *testing.T) {
 				Value: "test1",
 				Criteria: []TagCriteria{
 					{
-						Direction:   "asc",
+						Direction:   "src",
 						IPAddresses: []string{"1.2.3.4"},
 					},
 				},
@@ -336,7 +336,7 @@ func TestMultiPartBatch_Success(t *testing.T) {
 				Value: "test2",
 				Criteria: []TagCriteria{
 					{
-						Direction:   "asc",
+						Direction:   "src",
 						IPAddresses: []string{"2.2.3.4"},
 					},
 				},
@@ -345,7 +345,7 @@ func TestMultiPartBatch_Success(t *testing.T) {
 				Value: "test3",
 				Criteria: []TagCriteria{
 					{
-						Direction:   "asc",
+						Direction:   "src",
 						IPAddresses: []string{"3.2.3.4"},
 					},
 				},
@@ -354,7 +354,7 @@ func TestMultiPartBatch_Success(t *testing.T) {
 				Value: "test4",
 				Criteria: []TagCriteria{
 					{
-						Direction:   "asc",
+						Direction:   "src",
 						IPAddresses: []string{"4.2.3.4"},
 					},
 				},
@@ -363,7 +363,7 @@ func TestMultiPartBatch_Success(t *testing.T) {
 				Value: "test5",
 				Criteria: []TagCriteria{
 					{
-						Direction:   "asc",
+						Direction:   "src",
 						IPAddresses: []string{"5.2.3.4"},
 					},
 				},
@@ -425,10 +425,10 @@ func TestMultiPartBatch_PartialSuccess(t *testing.T) {
 	// expecting 2 requests
 	expectedRequests := []string{
 		// first request has no GUID, and has complete=false
-		`{"guid":"","replace_all":true,"ttl_minutes":0,"sender":{"service_name":"my-service","service_instance":"service-instance-1","host_name":"my-host-name"},"upserts":[{"value":"test5","criteria":[{"direction":"asc","addr":["5.2.3.4"]}]},{"value":"test4","criteria":[{"direction":"asc","addr":["4.2.3.4"]}]}],"complete":false}`,
+		`{"guid":"","replace_all":true,"ttl_minutes":0,"sender":{"service_name":"my-service","service_instance":"service-instance-1","host_name":"my-host-name"},"upserts":[{"value":"test5","criteria":[{"direction":"src","addr":["5.2.3.4"]}]},{"value":"test4","criteria":[{"direction":"src","addr":["4.2.3.4"]}]}],"complete":false}`,
 
 		// second request has the GUID, and also has complete=false, since there should be 3 parts, but we only send 2
-		`{"guid":"c8285742-f7a4-4870-933d-665b15c31eda","replace_all":true,"ttl_minutes":0,"sender":{"service_name":"my-service","service_instance":"service-instance-1","host_name":"my-host-name"},"upserts":[{"value":"test3","criteria":[{"direction":"asc","addr":["3.2.3.4"]}]},{"value":"test2","criteria":[{"direction":"asc","addr":["2.2.3.4"]}]}],"complete":false}`,
+		`{"guid":"c8285742-f7a4-4870-933d-665b15c31eda","replace_all":true,"ttl_minutes":0,"sender":{"service_name":"my-service","service_instance":"service-instance-1","host_name":"my-host-name"},"upserts":[{"value":"test3","criteria":[{"direction":"src","addr":["3.2.3.4"]}]},{"value":"test2","criteria":[{"direction":"src","addr":["2.2.3.4"]}]}],"complete":false}`,
 	}
 
 	lock := sync.Mutex{}
@@ -483,7 +483,7 @@ func TestMultiPartBatch_PartialSuccess(t *testing.T) {
 				Value: "test1",
 				Criteria: []TagCriteria{
 					{
-						Direction:   "asc",
+						Direction:   "src",
 						IPAddresses: []string{"1.2.3.4"},
 					},
 				},
@@ -492,7 +492,7 @@ func TestMultiPartBatch_PartialSuccess(t *testing.T) {
 				Value: "test2",
 				Criteria: []TagCriteria{
 					{
-						Direction:   "asc",
+						Direction:   "src",
 						IPAddresses: []string{"2.2.3.4"},
 					},
 				},
@@ -501,7 +501,7 @@ func TestMultiPartBatch_PartialSuccess(t *testing.T) {
 				Value: "test3",
 				Criteria: []TagCriteria{
 					{
-						Direction:   "asc",
+						Direction:   "src",
 						IPAddresses: []string{"3.2.3.4"},
 					},
 				},
@@ -510,7 +510,7 @@ func TestMultiPartBatch_PartialSuccess(t *testing.T) {
 				Value: "test4",
 				Criteria: []TagCriteria{
 					{
-						Direction:   "asc",
+						Direction:   "src",
 						IPAddresses: []string{"4.2.3.4"},
 					},
 				},
@@ -519,7 +519,7 @@ func TestMultiPartBatch_PartialSuccess(t *testing.T) {
 				Value: "test5",
 				Criteria: []TagCriteria{
 					{
-						Direction:   "asc",
+						Direction:   "src",
 						IPAddresses: []string{"5.2.3.4"},
 					},
 				},


### PR DESCRIPTION
BatchBuilder receives all Upserts, then splits them into batches by
sorting the upserts by serialized size, then loading batches first with
the biggest, the with the smaller. 

This fixes the problem that the previous implementation encountered, 
where all upserts were assumed to be roughly the same size. We'd split
the batches logically, without looking at individual upsert sizes. If many 
big ones were clustered together, that batch could be too big.