### PR TITLE
Handle unicode better in TruncateStringForMaxTagLen

### DIFF
--- a/hippo.go
+++ b/hippo.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 )
 
 type SendBatchResult struct {
@@ -348,7 +349,11 @@ func (c *Client) EnsureDimensions(ctx context.Context, apiHost string, required 
 
 func TruncateStringForMaxTagLen(str string) string {
 	if len(str) > MAX_TAG_LEN {
-		return str[0:MAX_TAG_LEN]
+		for i, s := range str {
+			if i >= MAX_TAG_LEN || i+utf8.RuneLen(rune(s)) > MAX_TAG_LEN {
+				return str[0:i]
+			}
+		}
 	}
 	return str
 }

--- a/hippo_test.go
+++ b/hippo_test.go
@@ -773,52 +773,65 @@ func TestTruncateStringForMaxTagLen(t *testing.T) {
 		name    string
 		input   string
 		isValid bool
+		exp     string
 	}{
 		{
 			name:    "short ascii",
 			input:   "some string",
 			isValid: true,
+			exp:     "some string",
 		},
 		{
 			name:    "long ascii",
 			input:   strings.Repeat("hi", MAX_TAG_LEN),
 			isValid: true,
+			exp:     strings.Repeat("hi", MAX_TAG_LEN/2),
 		},
 		{
 			name:    "very short unicode",
 			input:   "世界",
 			isValid: true,
+			exp:     "世界",
 		},
 		{
 			name:    "short unicode",
 			input:   strings.Repeat("世", MAX_TAG_LEN),
 			isValid: true,
+			exp:     strings.Repeat("世", MAX_TAG_LEN/3),
 		},
 		{
 			// trimming the last byte of a unicode char with rune length of 3, turns each of the remaining 2 bytes into 3 each
 			name:    "one len too big",
 			input:   strings.Repeat("世", MAX_TAG_LEN/len("世")+1),
 			isValid: true,
+			exp:     strings.Repeat("世", MAX_TAG_LEN/3),
 		},
 		{
 			name:    "long unicode",
 			input:   strings.Repeat("世界", MAX_TAG_LEN),
 			isValid: true,
+			exp:     strings.Repeat("世界", MAX_TAG_LEN/6),
 		},
 		{
 			name:    "long mixed",
 			input:   strings.Repeat("k", MAX_TAG_LEN+1) + strings.Repeat("世界", MAX_TAG_LEN),
 			isValid: true,
+			exp:     strings.Repeat("k", MAX_TAG_LEN),
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			oldWayLen := len(string([]rune(oldTruncateStringForMaxTagLen(tt.input))))
-			runeLen := len(string([]rune(TruncateStringForMaxTagLen(tt.input))))
+			var (
+				oldWayLen = len(string([]rune(oldTruncateStringForMaxTagLen(tt.input))))
+				truncated = string([]rune(TruncateStringForMaxTagLen(tt.input)))
+				runeLen   = len(truncated)
+			)
+
 			assert.Equal(t, tt.isValid, runeLen <= MAX_TAG_LEN)
 			if oldWayLen != runeLen {
 				t.Logf("%s: discrepancy between old [%d] and new [%d]", tt.name, oldWayLen, runeLen)
 			}
+			assert.Equal(t, tt.exp, truncated)
 		})
 	}
 }

--- a/hippo_test.go
+++ b/hippo_test.go
@@ -6,13 +6,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -758,4 +759,66 @@ func gzipUncompress(a *require.Assertions, data []byte) []byte {
 	a.NoError(err)
 
 	return resB.Bytes()
+}
+
+func oldTruncateStringForMaxTagLen(str string) string {
+	if len(str) > MAX_TAG_LEN {
+		return str[0:MAX_TAG_LEN]
+	}
+	return str
+}
+
+func TestTruncateStringForMaxTagLen(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		isValid bool
+	}{
+		{
+			name:    "short ascii",
+			input:   "some string",
+			isValid: true,
+		},
+		{
+			name:    "long ascii",
+			input:   strings.Repeat("hi", MAX_TAG_LEN),
+			isValid: true,
+		},
+		{
+			name:    "very short unicode",
+			input:   "世界",
+			isValid: true,
+		},
+		{
+			name:    "short unicode",
+			input:   strings.Repeat("世", MAX_TAG_LEN),
+			isValid: true,
+		},
+		{
+			// trimming the last byte of a unicode char with rune length of 3, turns each of the remaining 2 bytes into 3 each
+			name:    "one len too big",
+			input:   strings.Repeat("世", MAX_TAG_LEN/len("世")+1),
+			isValid: true,
+		},
+		{
+			name:    "long unicode",
+			input:   strings.Repeat("世界", MAX_TAG_LEN),
+			isValid: true,
+		},
+		{
+			name:    "long mixed",
+			input:   strings.Repeat("k", MAX_TAG_LEN+1) + strings.Repeat("世界", MAX_TAG_LEN),
+			isValid: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldWayLen := len(string([]rune(oldTruncateStringForMaxTagLen(tt.input))))
+			runeLen := len(string([]rune(TruncateStringForMaxTagLen(tt.input))))
+			assert.Equal(t, tt.isValid, runeLen <= MAX_TAG_LEN)
+			if oldWayLen != runeLen {
+				t.Logf("%s: discrepancy between old [%d] and new [%d]", tt.name, oldWayLen, runeLen)
+			}
+		})
+	}
 }


### PR DESCRIPTION
We noticed that if a unicode character crosses the `MAX_TAG_LEN` boundary, the current method of trimming it will turn each of it's remaining bytes into invalid runes of the same byte size as the original.

This fixes that.